### PR TITLE
Listing Stake With MAX and EEL pool under different pool groups.

### DIFF
--- a/pool_clusters.json
+++ b/pool_clusters.json
@@ -1055,11 +1055,12 @@
     "pool_id": "c7a434e33111ad62c0b99882c748e9e748c3442d161565661ad8dda4",
     "ticker": "EDEN"
   }],
-  "EEL": [{
+  "MAX1": [{
     "name": "Stake with Max",
     "pool_id": "9db81214b7b00001361999868ccc297d3bc076b4cabcb17c00277cfb",
     "ticker": "MAX1"
-  }, {
+  }],
+  "EEL": [{
     "name": "EEL",
     "pool_id": "a0022c62e100c18970d64feb7d0f8c08afe261e4d4435f5254ae92a7",
     "ticker": "EEL"

--- a/singlepooloperators.json
+++ b/singlepooloperators.json
@@ -1,4 +1,12 @@
 {
+  "a0022c62e100c18970d64feb7d0f8c08afe261e4d4435f5254ae92a7": {
+    "name": "EEL",
+    "ticker": "EEL"
+  },
+  "9db81214b7b00001361999868ccc297d3bc076b4cabcb17c00277cfb": {
+    "name": "Stake with Max",
+    "ticker": "MAX1"
+  },
   "0000066c3b2b15f7aece355a112ef141e9fe84d2e2152d4398986e40": {
     "name": "Silver City ",
     "ticker": "SILVR"


### PR DESCRIPTION
## Description
Separating Stake With MAX and EEL pool. As they do not belong to a pool group and are not using same pool resources.

## Where should the reviewer start?
There are only two file which are changed 
- [singlepooloperators.json](https://github.com/cardano-community/pool_groups/blob/main/singlepooloperators.json)
- [pool_clusters.json](https://github.com/cardano-community/pool_groups/blob/main/pool_clusters.json)

## Motivation and context
As both are showing as under same pool group. We wanted to change that.

## Which issue it fixes?



## How has this been tested?

